### PR TITLE
664 배 성능 향상

### DIFF
--- a/lib/last_prime_number.rb
+++ b/lib/last_prime_number.rb
@@ -12,6 +12,7 @@ class LastPrimeNumber
  	p_array = []
 
  	for p in 2..n
+ 		break if p > i
  		if is_prime_number(p)
  			while i % p == 0
  				p_array << p

--- a/lib/last_prime_number.rb
+++ b/lib/last_prime_number.rb
@@ -14,7 +14,7 @@ class LastPrimeNumber
  	p_array = []
 
  	for p in 2..n
- 		# break if p > i #0.011103855002147611 : 0.009555416996590793
+ 		break if p > i #0.011103855002147611 : 0.009555416996590793
  		if is_prime_number(p)
  			while i % p == 0
  				p_array << p

--- a/lib/last_prime_number.rb
+++ b/lib/last_prime_number.rb
@@ -41,8 +41,7 @@ Benchmark.bm do |x|
     lpn.big_prime(27637)
   }
   x.report {
-    # diff = Diff2.new(1, 100000)
-    # puts "Max #2 #{diff.max}"
+    
   }
 end
 

--- a/lib/last_prime_number.rb
+++ b/lib/last_prime_number.rb
@@ -1,3 +1,5 @@
+require 'benchmark'
+
 class LastPrimeNumber
  
  def initialize
@@ -12,7 +14,7 @@ class LastPrimeNumber
  	p_array = []
 
  	for p in 2..n
- 		break if p > i
+ 		# break if p > i #0.011103855002147611 : 0.009555416996590793
  		if is_prime_number(p)
  			while i % p == 0
  				p_array << p
@@ -32,3 +34,16 @@ class LastPrimeNumber
  	end
  end
 end
+
+Benchmark.bm do |x|
+  x.report {
+    lpn = LastPrimeNumber.new
+    lpn.big_prime(27637)
+  }
+  x.report {
+    # diff = Diff2.new(1, 100000)
+    # puts "Max #2 #{diff.max}"
+  }
+end
+
+

--- a/spec/last_prime_number_spec.rb
+++ b/spec/last_prime_number_spec.rb
@@ -1,7 +1,18 @@
 #encoding: utf-8
 require './lib/last_prime_number'
+require 'benchmark'
 
 RSpec.describe "마지막소수" do
+
+  # describe "#벤치마크" do
+  #   it 'takes time' do
+  #     Benchmark.realtime{
+  #       lpn = LastPrimeNumber.new
+  #       expect(lpn.big_prime(1013)).to eq(1013)  
+  #     }.should < 0
+  #   end
+  # end	
+
   describe "#가장큰 소수 구하기" do
     it '안녕?' do
       lpn = LastPrimeNumber.new
@@ -18,10 +29,21 @@ RSpec.describe "마지막소수" do
       expect(lpn.big_prime(1013)).to eq(1013)
     end
 
-    it '600851475143의 가장큰 소수?' do
-      lpn = LastPrimeNumber.new
-      expect(lpn.big_prime(600851475143)).to eq(6857)
-    end
+    # it '10130의 가장큰 소수?' do
+    #   lpn = LastPrimeNumber.new
+    #   expect(lpn.big_prime(10130)).to eq(1013)
+    # end
+
+    # it '860073923 가장큰 소수?' do
+    #   lpn = LastPrimeNumber.new
+    #   expect(lpn.big_prime(860073923)).to eq(953)
+    # end
+
+    # it '600851475143의 가장큰 소수?' do
+    #   lpn = LastPrimeNumber.new
+    #   expect(lpn.big_prime(600851475143)).to eq(6857)
+    # end
+
 
     
   end

--- a/spec/last_prime_number_spec.rb
+++ b/spec/last_prime_number_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe "마지막소수" do
 
     it '600851475143의 가장큰 소수?' do
       lpn = LastPrimeNumber.new
-      expect(lpn.big_prime(600851475143)).to eq(1013)
+      expect(lpn.big_prime(600851475143)).to eq(6857)
     end
 
     

--- a/spec/last_prime_number_spec.rb
+++ b/spec/last_prime_number_spec.rb
@@ -29,23 +29,20 @@ RSpec.describe "마지막소수" do
       expect(lpn.big_prime(1013)).to eq(1013)
     end
 
-    # it '10130의 가장큰 소수?' do
-    #   lpn = LastPrimeNumber.new
-    #   expect(lpn.big_prime(10130)).to eq(1013)
-    # end
+    it '10130의 가장큰 소수?' do
+      lpn = LastPrimeNumber.new
+      expect(lpn.big_prime(10130)).to eq(1013)
+    end
 
-    # it '860073923 가장큰 소수?' do
-    #   lpn = LastPrimeNumber.new
-    #   expect(lpn.big_prime(860073923)).to eq(953)
-    # end
+    it '860073923 가장큰 소수?' do
+      lpn = LastPrimeNumber.new
+      expect(lpn.big_prime(860073923)).to eq(953)
+    end
 
-    # it '600851475143의 가장큰 소수?' do
-    #   lpn = LastPrimeNumber.new
-    #   expect(lpn.big_prime(600851475143)).to eq(6857)
-    # end
-
-
-    
+    it '600851475143의 가장큰 소수?' do
+      lpn = LastPrimeNumber.new
+      expect(lpn.big_prime(600851475143)).to eq(6857)
+    end
   end
 
   describe "#소수인지 확인하기" do


### PR DESCRIPTION
27637 의 가장큰 소수를 구하는 상황에서 4.924084 : 0.007412 초로 664배 성능향상

before : a72ca85a8807da587a7c82845ed37f543d5252e8
[1] guard(main)>
22:15:40 - INFO - Run all
22:15:40 - INFO - Running all specs
       user     system      total        real
   4.740000   0.010000   4.750000 (  4.924084)
   0.000000   0.000000   0.000000 (  0.000003)

마지막소수
  #가장큰 소수 구하기
    안녕?
    6의 가장큰 소수?
    1013의 가장큰 소수?
  #소수인지 확인하기
    1 ?
    2 ?
    3 ?
    4 ?
    1013 ?

Finished in 0.01728 seconds (files took 5.07 seconds to load)
8 examples, 0 failures

after : 7b9dd7a00444cda5ebf42e9bf693b4781533c1d2
[1] guard(main)>
22:19:02 - INFO - Run all
22:19:02 - INFO - Running all specs
       user     system      total        real
   0.000000   0.000000   0.000000 (  0.007412)
   0.000000   0.000000   0.000000 (  0.000002)

마지막소수
  #가장큰 소수 구하기
    안녕?
    6의 가장큰 소수?
    1013의 가장큰 소수?
  #소수인지 확인하기
    1 ?
    2 ?
    3 ?
    4 ?
    1013 ?

Finished in 0.01357 seconds (files took 0.13027 seconds to load)
8 examples, 0 failures
